### PR TITLE
Use correct function to get UNIX time in post statitics

### DIFF
--- a/api/posters/statistics/helpers.ts
+++ b/api/posters/statistics/helpers.ts
@@ -1,6 +1,5 @@
 import AWS from 'aws-sdk'
 
-import {dateToUnixTimeStamp} from '@api/lib/date'
 import {logger} from '@nebula/log'
 import {Poster, PosterDocument, PosterSteps} from '@nebula/types/poster'
 
@@ -10,12 +9,8 @@ export const getCreatedPostersBetween = async (
   lowerBound: Date,
   upperBound: Date,
 ) =>
-  PosterModel.scan({
-    updatedAt: {
-      ge: dateToUnixTimeStamp(lowerBound),
-      le: dateToUnixTimeStamp(upperBound),
-    },
-  })
+  PosterModel.scan('updatedAt')
+    .between(lowerBound.valueOf(), upperBound.valueOf())
     .filter('step')
     .eq(PosterSteps.READY)
     .attributes(['posterData'])

--- a/api/posters/statistics/helpers.ts
+++ b/api/posters/statistics/helpers.ts
@@ -10,7 +10,7 @@ export const getCreatedPostersBetween = async (
   upperBound: Date,
 ) =>
   PosterModel.scan('updatedAt')
-    .between(lowerBound.valueOf(), upperBound.valueOf())
+    .between(lowerBound.getTime(), upperBound.getTime())
     .filter('step')
     .eq(PosterSteps.READY)
     .attributes(['posterData'])


### PR DESCRIPTION
Internally, `dateToUnixTimeStamp` divides by `1000` the value returned but dynamoDB stores complete values thus the need of only using `valueOf` from a `Date` object.

I noticed this by running the `scan` in the staging's table and it only returned 1 row, instead of the initial 12 during QA.